### PR TITLE
feat: Add required-label input

### DIFF
--- a/.github/workflows/apply-version-label-issue.yml
+++ b/.github/workflows/apply-version-label-issue.yml
@@ -1,0 +1,17 @@
+name: Apply version label to issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-version-label-issue:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          required-label: "Type: Upgrade Issue"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # actions-apply-version-label
 
 GitHub workflow used by the [react-native](https://github.com/facebook/react-native) repository to automatically add `Version: TAG` to issues tagged as `pre-release`.
+
+## Inputs
+
+### `github-token`
+
+**Required** The `GITHUB_TOKEN` secret.
+
+### `required-label`
+
+**Required** The required label for this action to run.
+
+## Example
+
+```
+- uses: gabrieldonadel/actions-apply-version-label@v0.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          required-label: "Type: Upgrade Issue"
+```
+

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "Apply version label to pre-release issue"
-description: "Automatically apply a version label to issues tagged with pre-release."
+name: "Apply version label to issue"
+description: "Automatically apply a version label to issues tagged with a specific label."
 
 branding:
   icon: "tag"
@@ -8,6 +8,9 @@ branding:
 inputs:
   github-token:
     description: The `GITHUB_TOKEN` secret.
+    required: true
+  required-label:
+    description: The required label for this action to run.
     required: true
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -8983,6 +8983,7 @@ const getLabelToBeApplied = (version) => version ? `${versionLabel}${version}` :
 const getIsIssueLabelAVersion = (label) => label.startsWith(versionLabel);
 const init = () => __awaiter(void 0, void 0, void 0, function* () {
     const githubToken = core.getInput("github-token", { required: true });
+    const requiredLabel = core.getInput("required-label", { required: true });
     const octokit = github.getOctokit(githubToken);
     const { issue } = github.context;
     // This fetches the issue again as it can have different data after running the other actions
@@ -9008,8 +9009,8 @@ const init = () => __awaiter(void 0, void 0, void 0, function* () {
         repo: issue.repo,
         issue_number: issue.number,
     });
-    if (labels.every(({ name }) => name !== "pre-release")) {
-        core.debug("Issue not tagged with pre-release");
+    if (labels.every(({ name }) => name !== requiredLabel)) {
+        core.debug(`Issue not tagged with ${requiredLabel}`);
         return;
     }
     // Loop through all labels and remove the version label if it exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ const getIsIssueLabelAVersion = (label: string) =>
 
 const init = async () => {
   const githubToken = core.getInput("github-token", { required: true });
+  const requiredLabel = core.getInput("required-label", { required: true });
   const octokit = github.getOctokit(githubToken);
 
   const { issue } = github.context;
@@ -123,8 +124,8 @@ const init = async () => {
     issue_number: issue.number,
   });
 
-  if (labels.every(({ name }) => name !== "pre-release")) {
-    core.debug("Issue not tagged with pre-release");
+  if (labels.every(({ name }) => name !== requiredLabel)) {
+    core.debug(`Issue not tagged with ${requiredLabel}`);
 
     return;
   }


### PR DESCRIPTION
## Description

 Add new `required-label` input so that users don't depend on one specific hard-coded issue as suggested by @lunaleaps here -> https://github.com/gabrieldonadel/actions-apply-version-label/commit/82afa877f408c01423b1eeb01781bdb461e9f9e6#r64521057

## How has this been tested?

Running ` act issues -e issue.json`

## Screenshots

![image](https://user-images.githubusercontent.com/11707729/150885656-19773d44-484c-4eec-abc1-9c56e76b521a.png)
 
