### PR TITLE
chore: Rename action to unique name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Apply version label to issue"
+name: "Apply version label to issue with specific label"
 description: "Automatically apply a version label to issues tagged with a specific label."
 
 branding:


### PR DESCRIPTION
## Description

Github was complaining that `Apply version label to issue` was not a unique name for an action, thus this renames it to `Apply version label to issue with specific label`
![image](https://user-images.githubusercontent.com/11707729/150889417-a98bbba6-c4cf-40af-9db1-865871891fee.png)



## How has this been tested?

N / A

## Screenshots

N / A
