### PR TITLE
feat: Update action to show a warning instead of throwing an error when label is missing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9049,8 +9049,7 @@ const init = () => __awaiter(void 0, void 0, void 0, function* () {
         });
     }
     catch (error) {
-        core.error(error);
-        core.setFailed(`Label ${labelToBeApplied} doesn't seem to exist`);
+        core.warning(`Label ${labelToBeApplied} doesn't seem to exist`);
     }
 });
 init();

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,9 +171,7 @@ const init = async () => {
       labels: [labelToBeApplied],
     });
   } catch (error) {
-    core.error(error);
-
-    core.setFailed(`Label ${labelToBeApplied} doesn't seem to exist`);
+    core.warning(`Label ${labelToBeApplied} doesn't seem to exist`);
   }
 };
 


### PR DESCRIPTION
## Description

Instead of throwing an error when the identified label does not exist we should just report a warning. 

Closes https://github.com/gabrieldonadel/actions-apply-version-label/issues/9

## How has this been tested?

`Running act issues -e issue.json`

## Screenshots

![image](https://user-images.githubusercontent.com/11707729/151380611-c835dfa1-6172-4b1a-b46d-79351ee9cc2f.png)

