### PR TITLE
chore: fix action name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # actions-apply-version-label
 
-GitHub workflow used by the [react-native](https://github.com/facebook/react-native) repository to automatically add `Version: TAG` to issues tagged with specific labels.
+GitHub workflow used by the [React Native](https://github.com/facebook/react-native) repository to automatically add `Version: TAG` to issues tagged with specific labels.
 
 ## Inputs
 
@@ -15,7 +15,7 @@ GitHub workflow used by the [react-native](https://github.com/facebook/react-nat
 ## Example
 
 ```
-- uses: gabrieldonadel/actions-apply-version-label@v0.0.1
+- uses: react-native-community/actions-apply-version-label@v0.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           required-label: "Type: Upgrade Issue"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GitHub workflow used by the [React Native](https://github.com/facebook/react-nat
 ## Example
 
 ```
-- uses: react-native-community/actions-apply-version-label@v0.0.1
+- uses: react-native-community/actions-apply-version-label@v0.0.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           required-label: "Type: Upgrade Issue"


### PR DESCRIPTION
## Description

It looks like the example listed in Readme file include the old action name.

## How has this been tested?

https://github.com/facebook/react-native/blob/main/.github/workflows/apply-version-label-issue.yml#L13

## Screenshots

N/A
